### PR TITLE
wiringPi: allow external pins in pinMode, digitalRead, digitalWrite

### DIFF
--- a/Code/devterm_wiringpi_cpi/wiringPi/wiringPi.c
+++ b/Code/devterm_wiringpi_cpi/wiringPi/wiringPi.c
@@ -1446,7 +1446,14 @@ void pinMode (int pin, int mode)
   setupCheck ("pinMode") ;
 
 #ifdef CONFIG_CLOCKWORKPI
-  CPiPinMode(pin, mode);
+
+  if ((pin & PI_GPIO_MASK) == 0)		// On-board pin
+  {
+    CPiPinMode(pin, mode);
+  } else if ((node = wiringPiFindNode (pin)) != NULL)
+  {
+      node->pinMode (node, pin, mode) ;
+  }
   return;
 #endif
 
@@ -1565,7 +1572,14 @@ int digitalRead (int pin)
   struct wiringPiNodeStruct *node = wiringPiNodes ;
 
 #ifdef CONFIG_CLOCKWORKPI
-  return CPiDigitalRead(pin);
+  if ((pin & PI_GPIO_MASK) == 0)		// On-Board Pin
+  {
+    return CPiDigitalRead(pin);
+  } else {
+    if ((node = wiringPiFindNode (pin)) == NULL)
+      return LOW ;
+    return node->digitalRead (node, pin) ;
+  }
 #endif
 
   if ((pin & PI_GPIO_MASK) == 0)		// On-Board Pin
@@ -1632,7 +1646,13 @@ void digitalWrite (int pin, int value)
   struct wiringPiNodeStruct *node = wiringPiNodes ;
 
 #ifdef CONFIG_CLOCKWORKPI
-  CPiDigitalWrite(pin, value);
+  if ((pin & PI_GPIO_MASK) == 0)		// On-Board Pin
+  {
+    CPiDigitalWrite(pin, value);
+  } else {
+    if ((node = wiringPiFindNode (pin)) != NULL)
+      node->digitalWrite (node, pin, value) ;
+  }
   return;
 #endif
 


### PR DESCRIPTION
This patch allows external pins the way WiringPi is designed to.
For example, one can setup mcp23008 and base it at pin 100 like this:

```c
  if (1 != mcp23008Setup(100, 0x20)) {
    die("Failed to setup mcp23008\n");
  }
  // ...
  pinMode(100, INPUT);
  digitalRead(100);
```

Without this patch, the WiringCPi logic intercepts the requests and report "invalid pin".