### PR TITLE
Add thermal_printer command to print images using 4 colors.

### DIFF
--- a/Code/thermal_printer/config.h
+++ b/Code/thermal_printer/config.h
@@ -167,12 +167,13 @@
 #define PRINT_STATE 0
 #define ESC_STATE 1
 #define GET_IMAGE 2
+#define GET_GRAY_IMAGE 3
 
 #define ALIGN_LEFT 0
 #define ALIGN_CENTER 1
 #define ALIGN_RIGHT 2
 
-#define IMAGE_MAX 9224
+#define IMAGE_MAX (9224*64)
 
 #define BITS8 8
 

--- a/Code/thermal_printer/printer.h
+++ b/Code/thermal_printer/printer.h
@@ -37,6 +37,7 @@ uint8_t print_lines8(CONFIG *,int,int);
 uint8_t invert_bit(uint8_t a);
 
 uint8_t print_image8(CONFIG *);
+uint8_t print_gray_image8(CONFIG *);
 void print_cut_line(CONFIG *);
 
 void printer_set_font_mode(CONFIG *cfg, int);


### PR DESCRIPTION
Hi! 

I've implemented a function for printing grayscale images, that works in a similar way as a monochrome print, but with a few differences:
1. Paper will stay in place while printing all 3 non-white 'colors' sequentially, it will be moved after printing the third color. Colors are calculated from cfg: white color, density/4, density/2, density. 
2. User now needs to send 3 rows of color bitstrings for each image row. Colors are mutually exclusive. Each row follows  monochrome image format. 
3. Header's height field now accounts data row count, not pixel rows, i.e. it needs to be multiplied by 3.
4. Command id is different: cmd[0] == ASCII_GS && cmd[1] == 118 && cmd[2] == 49

E.g. for image 200x200, user needs to send header with width 200, height 600. 
Image data is arranged the following way (fourth color is blank, i.e. zero bits): 
25 bytes (200bits) of 1st color for first row
25 bytes (200bits) of 2nd color for first row
25 bytes (200bits) of 3rd color for first row
25 bytes (200bits) of 1st color for second row
25 bytes (200bits) of 2nd color for second row
...etc...
25 * 3 * 200 bytes total.

Example 4 color image with comparison to monochrome print:
![shades](https://user-images.githubusercontent.com/2056370/232332437-2855dd18-3b3b-488d-baa3-3e1074224567.png)


P.S. There is one minor change, that touches previous print function - I got better results when in print_dots_8bit I repeated heat cycles _cfg->density_ times instead of hardcoded  _10_ times.
