### PR TITLE
Fix Battery Charge Current in PMU Devicetree Overlay

### DIFF
--- a/Code/patch/cm4/cm4_kernel_0704.patch
+++ b/Code/patch/cm4/cm4_kernel_0704.patch
@@ -308,7 +308,7 @@ index 000000000000..3ffc51b8fc2d
 +		__overlay__  {
 +			battery: battery@0 {
 +				compatible = "simple-battery";
-+				constant_charge_current_max_microamp = <2100000>;
++				constant-charge-current-max-microamp = <2100000>;
 +				voltage-min-design-microvolt = <3300000>;
 +			};
 +		};


### PR DESCRIPTION
Similar to uConsole, the same typo exists here; this fixes it and results in the intended battery charge current.

uConsole PR for reference: https://github.com/clockworkpi/uConsole/pull/19